### PR TITLE
removing missleading/outdated URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Import https://raw.githubusercontent.com/Mobicents/juju-charms/master/mobicents-
 
 #Test RestComm Charm
 
-Go to http://<public_ip>:8080/restcomm-management or http://<public_ip>:8080/restcomm-management (username: administrator@company.com, password: RestComm) for Admininstration
+Go to http://<public_ip>:8080  (username: administrator@company.com, password: RestComm) for Admininstration
 
 ## WebRTC call
 


### PR DESCRIPTION
This url to access management GUI is ok: http://<public_ip>:8080 
But if after deployment user access this url http://<public_ip>:8080/restcomm-management he/she is getting 404 error: 

JBWEB000065: HTTP Status 404 - /restcomm-management
JBWEB000309: type JBWEB000067: Status reporte
JBWEB000068: message /restcomm-management

JBWEB000069: description JBWEB000124: The requested resource is not available.
JBoss Web/7.2.0.Final
